### PR TITLE
SetDefaultVerifyLocations to load default trust store.

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -14,6 +14,7 @@
 
 package openssl
 
+// #include <openssl/ssl.h>
 // #include "shim.h"
 import "C"
 
@@ -565,4 +566,12 @@ func (c *Ctx) SessSetCacheSize(t int) int {
 // https://www.openssl.org/docs/ssl/SSL_CTX_sess_set_cache_size.html
 func (c *Ctx) SessGetCacheSize() int {
 	return int(C.X_SSL_CTX_sess_get_cache_size(c.ctx))
+}
+
+// SetDefaultVerifyLocations
+// https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_set_default_verify_paths.html
+// enables automatical loading of default trust store from the `certs' subdirectory
+// and `cert.pem' file in the OPENSSL_DIR (check with `openssl version -d')
+func (c *Ctx) SetDefaultVerifyLocations() int {
+	return int(C.SSL_CTX_set_default_verify_paths(c.ctx))
 }


### PR DESCRIPTION
Enable to load the system-wide trusted CAs certificates by default.

 * https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_set_default_verify_paths.html
   enables automatical loading of default trust store from the 'certs' subdirectory
   and 'cert.pem' file in the OPENSSL_DIR (check with 'openssl version -d')
 * wrapper around SSL_CTX_set_default_verify_paths

Signed-off-by: Peter Grzybowski <peter@northern.tech>