### PR TITLE
MEN-3877: Protect dynamic c structures from accidental free

### DIFF
--- a/ciphers_gcm.go
+++ b/ciphers_gcm.go
@@ -20,6 +20,7 @@ import "C"
 import (
 	"errors"
 	"fmt"
+	"runtime"
 )
 
 type AuthenticatedEncryptionCipherCtx interface {
@@ -90,6 +91,8 @@ func NewGCMEncryptionCipherCtx(blocksize int, e *Engine, key, iv []byte) (
 			(*C.uchar)(&iv[0])) {
 			return nil, errors.New("failed to apply IV")
 		}
+		runtime.KeepAlive(ctx)
+		runtime.KeepAlive(iv)
 	}
 	return &authEncryptionCipherCtx{encryptionCipherCtx: ctx}, nil
 }
@@ -114,6 +117,8 @@ func NewGCMDecryptionCipherCtx(blocksize int, e *Engine, key, iv []byte) (
 			(*C.uchar)(&iv[0])) {
 			return nil, errors.New("failed to apply IV")
 		}
+		runtime.KeepAlive(ctx)
+		runtime.KeepAlive(iv)
 	}
 	return &authDecryptionCipherCtx{decryptionCipherCtx: ctx}, nil
 }
@@ -127,6 +132,8 @@ func (ctx *authEncryptionCipherCtx) ExtraData(aad []byte) error {
 		C.int(len(aad))) {
 		return errors.New("failed to add additional authenticated data")
 	}
+	runtime.KeepAlive(ctx)
+	runtime.KeepAlive(aad)
 	return nil
 }
 
@@ -139,6 +146,8 @@ func (ctx *authDecryptionCipherCtx) ExtraData(aad []byte) error {
 		C.int(len(aad))) {
 		return errors.New("failed to add additional authenticated data")
 	}
+	runtime.KeepAlive(ctx)
+	runtime.KeepAlive(aad)
 	return nil
 }
 

--- a/ctx.go
+++ b/ctx.go
@@ -197,6 +197,7 @@ func (c *Ctx) SetEllipticCurve(curve EllipticCurve) error {
 	if int(C.X_SSL_CTX_set_tmp_ecdh(c.ctx, k)) != 1 {
 		return errorFromErrorQueue()
 	}
+	runtime.KeepAlive(c)
 
 	return nil
 }
@@ -210,6 +211,7 @@ func (c *Ctx) UseCertificate(cert *Certificate) error {
 	if int(C.SSL_CTX_use_certificate(c.ctx, cert.x)) != 1 {
 		return errorFromErrorQueue()
 	}
+	runtime.KeepAlive(c)
 	return nil
 }
 
@@ -222,6 +224,7 @@ func (c *Ctx) AddChainCertificate(cert *Certificate) error {
 	if int(C.X_SSL_CTX_add_extra_chain_cert(c.ctx, cert.x)) != 1 {
 		return errorFromErrorQueue()
 	}
+	runtime.KeepAlive(c)
 	// OpenSSL takes ownership via SSL_CTX_add_extra_chain_cert
 	runtime.SetFinalizer(cert, nil)
 	return nil
@@ -236,6 +239,8 @@ func (c *Ctx) UsePrivateKey(key PrivateKey) error {
 	if int(C.SSL_CTX_use_PrivateKey(c.ctx, key.evpPKey())) != 1 {
 		return errorFromErrorQueue()
 	}
+	runtime.KeepAlive(c)
+	runtime.KeepAlive(key)
 	return nil
 }
 
@@ -255,6 +260,8 @@ func (c *Ctx) UseCertAndExternalKey(cert *Certificate) error {
 	if int(C.SSL_CTX_use_cert_and_key(c.ctx, cert.x, nil, nil, 0)) != 1 {
 		return errorFromErrorQueue()
 	}
+	runtime.KeepAlive(c)
+	runtime.KeepAlive(cert)
 	return nil
 }
 
@@ -270,9 +277,11 @@ func (c *Ctx) UseCertAndKey(cert *Certificate, key *PrivateKey) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 	c.key = *key
-	if int(C.SSL_CTX_use_cert_and_key(c.ctx, cert.x, (*key).evpPKey(), nil, 0)) != 1 {
+	if int(C.SSL_CTX_use_cert_and_key(c.ctx, cert.x, c.key.evpPKey(), nil, 0)) != 1 {
 		return errorFromErrorQueue()
 	}
+	runtime.KeepAlive(c)
+	runtime.KeepAlive(cert)
 	return nil
 }
 
@@ -319,7 +328,8 @@ func (c *Ctx) GetCertificateStore() *CertificateStore {
 	// to a ctx internal. so we do need to keep the ctx around
 	return &CertificateStore{
 		store: C.SSL_CTX_get_cert_store(c.ctx),
-		ctx:   c}
+		ctx:   c,
+	}
 }
 
 // AddCertificate marks the provided Certificate as a trusted certificate in
@@ -331,6 +341,8 @@ func (s *CertificateStore) AddCertificate(cert *Certificate) error {
 	if int(C.X509_STORE_add_cert(s.store, cert.x)) != 1 {
 		return errorFromErrorQueue()
 	}
+	runtime.KeepAlive(s)
+	runtime.KeepAlive(cert)
 	return nil
 }
 
@@ -340,11 +352,14 @@ type CertificateStoreCtx struct {
 }
 
 func (self *CertificateStoreCtx) VerifyResult() VerifyResult {
-	return VerifyResult(C.X509_STORE_CTX_get_error(self.ctx))
+	result := C.X509_STORE_CTX_get_error(self.ctx)
+	runtime.KeepAlive(self)
+	return VerifyResult(result)
 }
 
 func (self *CertificateStoreCtx) Err() error {
 	code := C.X509_STORE_CTX_get_error(self.ctx)
+	runtime.KeepAlive(self)
 	if code == C.X509_V_OK {
 		return nil
 	}
@@ -353,13 +368,16 @@ func (self *CertificateStoreCtx) Err() error {
 }
 
 func (self *CertificateStoreCtx) Depth() int {
-	return int(C.X509_STORE_CTX_get_error_depth(self.ctx))
+	depth := C.X509_STORE_CTX_get_error_depth(self.ctx)
+	runtime.KeepAlive(self)
+	return int(depth)
 }
 
 // the certicate returned is only valid for the lifetime of the underlying
 // X509_STORE_CTX
 func (self *CertificateStoreCtx) GetCurrentCert() *Certificate {
 	x509 := C.X509_STORE_CTX_get_current_cert(self.ctx)
+	runtime.KeepAlive(self)
 	if x509 == nil {
 		return nil
 	}
@@ -395,6 +413,7 @@ func (c *Ctx) LoadVerifyLocations(ca_file string, ca_path string) error {
 	if C.SSL_CTX_load_verify_locations(c.ctx, c_ca_file, c_ca_path) != 1 {
 		return errorFromErrorQueue()
 	}
+	runtime.KeepAlive(c)
 	return nil
 }
 
@@ -414,19 +433,27 @@ const (
 // SetOptions sets context options. See
 // http://www.openssl.org/docs/ssl/SSL_CTX_set_options.html
 func (c *Ctx) SetOptions(options Options) Options {
-	return Options(C.X_SSL_CTX_set_options(
-		c.ctx, C.long(options)))
+	opts := C.X_SSL_CTX_set_options(
+		c.ctx, C.long(options),
+	)
+	runtime.KeepAlive(c)
+	return Options(opts)
 }
 
 func (c *Ctx) ClearOptions(options Options) Options {
-	return Options(C.X_SSL_CTX_clear_options(
-		c.ctx, C.long(options)))
+	opts := C.X_SSL_CTX_clear_options(
+		c.ctx, C.long(options),
+	)
+	runtime.KeepAlive(c)
+	return Options(opts)
 }
 
 // GetOptions returns context options. See
 // https://www.openssl.org/docs/ssl/SSL_CTX_set_options.html
 func (c *Ctx) GetOptions() Options {
-	return Options(C.X_SSL_CTX_get_options(c.ctx))
+	opts := C.X_SSL_CTX_get_options(c.ctx)
+	runtime.KeepAlive(c)
+	return Options(opts)
 }
 
 type Modes int
@@ -439,13 +466,17 @@ const (
 // SetMode sets context modes. See
 // http://www.openssl.org/docs/ssl/SSL_CTX_set_mode.html
 func (c *Ctx) SetMode(modes Modes) Modes {
-	return Modes(C.X_SSL_CTX_set_mode(c.ctx, C.long(modes)))
+	mode := C.X_SSL_CTX_set_mode(c.ctx, C.long(modes))
+	runtime.KeepAlive(c)
+	return Modes(mode)
 }
 
 // GetMode returns context modes. See
 // http://www.openssl.org/docs/ssl/SSL_CTX_set_mode.html
 func (c *Ctx) GetMode() Modes {
-	return Modes(C.X_SSL_CTX_get_mode(c.ctx))
+	mode := C.X_SSL_CTX_get_mode(c.ctx)
+	runtime.KeepAlive(c)
+	return Modes(mode)
 }
 
 type VerifyOptions int
@@ -488,6 +519,7 @@ func (c *Ctx) SetVerify(options VerifyOptions, verify_cb VerifyCallback) {
 	} else {
 		C.SSL_CTX_set_verify(c.ctx, C.int(options), nil)
 	}
+	runtime.KeepAlive(c)
 }
 
 func (c *Ctx) SetVerifyMode(options VerifyOptions) {
@@ -503,7 +535,9 @@ func (c *Ctx) GetVerifyCallback() VerifyCallback {
 }
 
 func (c *Ctx) VerifyMode() VerifyOptions {
-	return VerifyOptions(C.SSL_CTX_get_verify_mode(c.ctx))
+	opts := C.SSL_CTX_get_verify_mode(c.ctx)
+	runtime.KeepAlive(c)
+	return VerifyOptions(opts)
 }
 
 // SetVerifyDepth controls how many certificates deep the certificate
@@ -511,13 +545,16 @@ func (c *Ctx) VerifyMode() VerifyOptions {
 // https://www.openssl.org/docs/ssl/SSL_CTX_set_verify.html
 func (c *Ctx) SetVerifyDepth(depth int) {
 	C.SSL_CTX_set_verify_depth(c.ctx, C.int(depth))
+	runtime.KeepAlive(c)
 }
 
 // GetVerifyDepth controls how many certificates deep the certificate
 // verification logic is willing to follow a certificate chain. See
 // https://www.openssl.org/docs/ssl/SSL_CTX_set_verify.html
 func (c *Ctx) GetVerifyDepth() int {
-	return int(C.SSL_CTX_get_verify_depth(c.ctx))
+	depth := C.SSL_CTX_get_verify_depth(c.ctx)
+	runtime.KeepAlive(c)
+	return int(depth)
 }
 
 type TLSExtServernameCallback func(ssl *SSL) SSLTLSExtErr
@@ -528,6 +565,7 @@ type TLSExtServernameCallback func(ssl *SSL) SSLTLSExtErr
 func (c *Ctx) SetTLSExtServernameCallback(sni_cb TLSExtServernameCallback) {
 	c.sni_cb = sni_cb
 	C.X_SSL_CTX_set_tlsext_servername_callback(c.ctx, (*[0]byte)(C.sni_cb))
+	runtime.KeepAlive(c)
 }
 
 func (c *Ctx) SetSessionId(session_id []byte) error {
@@ -541,6 +579,8 @@ func (c *Ctx) SetSessionId(session_id []byte) error {
 		C.uint(len(session_id)))) == 0 {
 		return errorFromErrorQueue()
 	}
+	runtime.KeepAlive(c)
+	runtime.KeepAlive(session_id)
 	return nil
 }
 
@@ -555,6 +595,7 @@ func (c *Ctx) SetCipherList(list string) error {
 	if int(C.SSL_CTX_set_cipher_list(c.ctx, clist)) == 0 {
 		return errorFromErrorQueue()
 	}
+	runtime.KeepAlive(c)
 	return nil
 }
 
@@ -574,39 +615,53 @@ const (
 // SetSessionCacheMode enables or disables session caching. See
 // http://www.openssl.org/docs/ssl/SSL_CTX_set_session_cache_mode.html
 func (c *Ctx) SetSessionCacheMode(modes SessionCacheModes) SessionCacheModes {
-	return SessionCacheModes(
-		C.X_SSL_CTX_set_session_cache_mode(c.ctx, C.long(modes)))
+	cacheModes := C.X_SSL_CTX_set_session_cache_mode(c.ctx, C.long(modes))
+	runtime.KeepAlive(c)
+	return SessionCacheModes(cacheModes)
 }
 
 // Set session cache timeout. Returns previously set value.
 // See https://www.openssl.org/docs/ssl/SSL_CTX_set_timeout.html
 func (c *Ctx) SetTimeout(t time.Duration) time.Duration {
 	prev := C.X_SSL_CTX_set_timeout(c.ctx, C.long(t/time.Second))
+	runtime.KeepAlive(c)
 	return time.Duration(prev) * time.Second
 }
 
 // Get session cache timeout.
 // See https://www.openssl.org/docs/ssl/SSL_CTX_set_timeout.html
 func (c *Ctx) GetTimeout() time.Duration {
-	return time.Duration(C.X_SSL_CTX_get_timeout(c.ctx)) * time.Second
+	timeout := time.Duration(C.X_SSL_CTX_get_timeout(c.ctx)) * time.Second
+	runtime.KeepAlive(c)
+	return timeout
 }
 
 // Set session cache size. Returns previously set value.
 // https://www.openssl.org/docs/ssl/SSL_CTX_sess_set_cache_size.html
 func (c *Ctx) SessSetCacheSize(t int) int {
-	return int(C.X_SSL_CTX_sess_set_cache_size(c.ctx, C.long(t)))
+	ret := C.X_SSL_CTX_sess_set_cache_size(c.ctx, C.long(t))
+	runtime.KeepAlive(c)
+	return int(ret)
 }
 
 // Get session cache size.
 // https://www.openssl.org/docs/ssl/SSL_CTX_sess_set_cache_size.html
 func (c *Ctx) SessGetCacheSize() int {
-	return int(C.X_SSL_CTX_sess_get_cache_size(c.ctx))
+	cacheSize := C.X_SSL_CTX_sess_get_cache_size(c.ctx)
+	runtime.KeepAlive(c)
+	return int(cacheSize)
 }
 
 // SetDefaultVerifyPaths
 // https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_set_default_verify_paths.html
 // enables automatic loading of the default trust store from the `certs' subdirectory
 // and `cert.pem' file in the OPENSSL_DIR (check with `openssl version -d')
-func (c *Ctx) SetDefaultVerifyPaths() int {
-	return int(C.SSL_CTX_set_default_verify_paths(c.ctx))
+func (c *Ctx) SetDefaultVerifyPaths() error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	ret := C.SSL_CTX_set_default_verify_paths(c.ctx)
+	if ret == 0 {
+		return errorFromErrorQueue()
+	}
+	return nil
 }

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -65,8 +65,8 @@ func TestCtxSetDefaultVerifyLocations(t *testing.T) {
 		t.Error("cant create context")
 	}
 
-	if ctx.SetDefaultVerifyPaths() != 1 {
-		t.Errorf("set_default_verify_paths OpenSSL call failed")
+	if err := ctx.SetDefaultVerifyPaths(); err != nil {
+		t.Errorf("set_default_verify_paths OpenSSL call failed: %v", err)
 	}
 
 	conn, err = Dial("tcp", "google.com:443", ctx, 0)

--- a/dh.go
+++ b/dh.go
@@ -18,6 +18,7 @@ package openssl
 import "C"
 import (
 	"errors"
+	"runtime"
 	"unsafe"
 )
 
@@ -28,6 +29,7 @@ import (
 func DeriveSharedSecret(private PrivateKey, public PublicKey) ([]byte, error) {
 	// Create context for the shared secret derivation
 	dhCtx := C.EVP_PKEY_CTX_new(private.evpPKey(), nil)
+	runtime.KeepAlive(private)
 	if dhCtx == nil {
 		return nil, errors.New("failed creating shared secret derivation context")
 	}
@@ -42,6 +44,7 @@ func DeriveSharedSecret(private PrivateKey, public PublicKey) ([]byte, error) {
 	if int(C.EVP_PKEY_derive_set_peer(dhCtx, public.evpPKey())) != 1 {
 		return nil, errors.New("failed adding peer public key to context")
 	}
+	runtime.KeepAlive(public)
 
 	// Determine how large of a buffer we need for the shared secret
 	var buffLen C.size_t

--- a/dhparam.go
+++ b/dhparam.go
@@ -60,5 +60,7 @@ func (c *Ctx) SetDHParameters(dh *DH) error {
 	if int(C.X_SSL_CTX_set_tmp_dh(c.ctx, dh.dh)) != 1 {
 		return errorFromErrorQueue()
 	}
+	runtime.KeepAlive(c)
+	runtime.KeepAlive(dh)
 	return nil
 }

--- a/hmac.go
+++ b/hmac.go
@@ -70,6 +70,7 @@ func (h *HMAC) Write(data []byte) (n int, err error) {
 		C.size_t(len(data))); rc != 1 {
 		return 0, errors.New("failed to update HMAC")
 	}
+	runtime.KeepAlive(h)
 	return len(data), nil
 }
 
@@ -77,6 +78,7 @@ func (h *HMAC) Reset() error {
 	if 1 != C.X_HMAC_Init_ex(h.ctx, nil, 0, nil, nil) {
 		return errors.New("failed to reset HMAC_CTX")
 	}
+	runtime.KeepAlive(h)
 	return nil
 }
 
@@ -87,5 +89,6 @@ func (h *HMAC) Final() (result []byte, err error) {
 		(*C.uint)(unsafe.Pointer(&mdLength))); rc != 1 {
 		return nil, errors.New("failed to finalized HMAC")
 	}
+	runtime.KeepAlive(result)
 	return result, h.Reset()
 }

--- a/hostname.go
+++ b/hostname.go
@@ -36,6 +36,7 @@ import "C"
 import (
 	"errors"
 	"net"
+	"runtime"
 	"unsafe"
 )
 
@@ -61,6 +62,7 @@ func (c *Certificate) CheckHost(host string, flags CheckFlags) error {
 
 	rv := C.X509_check_host(c.x, (*C.uchar)(chost), C.size_t(len(host)),
 		C.uint(flags), nil)
+	runtime.KeepAlive(c)
 	if rv > 0 {
 		return nil
 	}
@@ -80,6 +82,7 @@ func (c *Certificate) CheckEmail(email string, flags CheckFlags) error {
 	defer C.free(cemail)
 	rv := C.X509_check_email(c.x, (*C.uchar)(cemail), C.size_t(len(email)),
 		C.uint(flags))
+	runtime.KeepAlive(c)
 	if rv > 0 {
 		return nil
 	}
@@ -104,6 +107,7 @@ func (c *Certificate) CheckIP(ip net.IP, flags CheckFlags) error {
 	cip := unsafe.Pointer(&ip[0])
 	rv := C.X509_check_ip(c.x, (*C.uchar)(cip), C.size_t(len(ip)),
 		C.uint(flags))
+	runtime.KeepAlive(c)
 	if rv > 0 {
 		return nil
 	}

--- a/key.go
+++ b/key.go
@@ -61,6 +61,8 @@ const (
 	KeyTypeED448   = NID_ED448
 )
 
+const DefaultRSAExponent = 0x10001
+
 type PublicKey interface {
 	// Verifies the data signature using PKCS1.15
 	VerifyPKCS1v15(method Method, data, sig []byte) error
@@ -451,7 +453,7 @@ func LoadPublicKeyFromDER(der_block []byte) (PublicKey, error) {
 
 // GenerateRSAKey generates a new RSA private key with an exponent of 65537.
 func GenerateRSAKey(bits int) (PrivateKey, error) {
-	return GenerateRSAKeyWithExponent(bits, 65537)
+	return GenerateRSAKeyWithExponent(bits, DefaultRSAExponent)
 }
 
 // GenerateRSAKeyWithExponent generates a new RSA private key.
@@ -486,6 +488,8 @@ func GenerateRSAKeyWithExponent(bits int, exponent int) (PrivateKey, error) {
 	}
 	p := &pKey{key: key}
 	runtime.SetFinalizer(p, func(p *pKey) {
+		// At this point the RSA struct pointed to by the "rsa" variable
+		// is owned by the EVP_PKEY struct and will be freed py the Finalizer
 		C.X_EVP_PKEY_free(p.key)
 	})
 	return p, nil

--- a/key.go
+++ b/key.go
@@ -112,11 +112,15 @@ type pKey struct {
 func (key *pKey) evpPKey() *C.EVP_PKEY { return key.key }
 
 func (key *pKey) KeyType() NID {
-	return NID(C.EVP_PKEY_id(key.key))
+	nid := C.EVP_PKEY_id(key.key)
+	runtime.KeepAlive(key)
+	return NID(nid)
 }
 
 func (key *pKey) BaseType() NID {
-	return NID(C.EVP_PKEY_base_id(key.key))
+	nid := C.EVP_PKEY_base_id(key.key)
+	runtime.KeepAlive(key)
+	return NID(nid)
 }
 
 func (key *pKey) SignPKCS1v15(method Method, data []byte) ([]byte, error) {
@@ -145,7 +149,8 @@ func (key *pKey) SignPKCS1v15(method Method, data []byte) ([]byte, error) {
 			C.size_t(len(data))) {
 			return nil, errors.New("signpkcs1v15: failed to do one-shot signature")
 		}
-
+		runtime.KeepAlive(key)
+		runtime.KeepAlive(data)
 		return sig[:sigblen], nil
 	} else {
 		if 1 != C.X_EVP_SignInit(ctx, method) {
@@ -156,6 +161,7 @@ func (key *pKey) SignPKCS1v15(method Method, data []byte) ([]byte, error) {
 				ctx, unsafe.Pointer(&data[0]), C.uint(len(data))) {
 				return nil, errors.New("signpkcs1v15: failed to update signature")
 			}
+			runtime.KeepAlive(data)
 		}
 		sig := make([]byte, C.X_EVP_PKEY_size(key.key))
 		var sigblen C.uint
@@ -163,6 +169,7 @@ func (key *pKey) SignPKCS1v15(method Method, data []byte) ([]byte, error) {
 			((*C.uchar)(unsafe.Pointer(&sig[0]))), &sigblen, key.key) {
 			return nil, errors.New("signpkcs1v15: failed to finalize signature")
 		}
+		runtime.KeepAlive(key)
 		return sig[:sigblen], nil
 	}
 }
@@ -189,7 +196,9 @@ func (key *pKey) VerifyPKCS1v15(method Method, data, sig []byte) error {
 			C.size_t(len(data))) {
 			return errors.New("verifypkcs1v15: failed to do one-shot verify")
 		}
-
+		runtime.KeepAlive(data)
+		runtime.KeepAlive(sig)
+		runtime.KeepAlive(key)
 		return nil
 
 	} else {
@@ -206,6 +215,9 @@ func (key *pKey) VerifyPKCS1v15(method Method, data, sig []byte) error {
 			((*C.uchar)(unsafe.Pointer(&sig[0]))), C.uint(len(sig)), key.key) {
 			return errors.New("verifypkcs1v15: failed to finalize verify")
 		}
+		runtime.KeepAlive(data)
+		runtime.KeepAlive(sig)
+		runtime.KeepAlive(key)
 		return nil
 	}
 }
@@ -225,6 +237,7 @@ func (key *pKey) MarshalPKCS1PrivateKeyPEM() (pem_block []byte,
 		C.int(0), nil, nil)) != 1 {
 		return nil, errors.New("failed dumping private key")
 	}
+	runtime.KeepAlive(key)
 
 	return ioutil.ReadAll(asAnyBio(bio))
 }
@@ -240,6 +253,7 @@ func (key *pKey) MarshalPKCS1PrivateKeyDER() (der_block []byte,
 	if int(C.i2d_PrivateKey_bio(bio, key.key)) != 1 {
 		return nil, errors.New("failed dumping private key der")
 	}
+	runtime.KeepAlive(key)
 
 	return ioutil.ReadAll(asAnyBio(bio))
 }
@@ -255,6 +269,7 @@ func (key *pKey) MarshalPKIXPublicKeyPEM() (pem_block []byte,
 	if int(C.PEM_write_bio_PUBKEY(bio, key.key)) != 1 {
 		return nil, errors.New("failed dumping public key pem")
 	}
+	runtime.KeepAlive(key)
 
 	return ioutil.ReadAll(asAnyBio(bio))
 }
@@ -270,6 +285,7 @@ func (key *pKey) MarshalPKIXPublicKeyDER() (der_block []byte,
 	if int(C.i2d_PUBKEY_bio(bio, key.key)) != 1 {
 		return nil, errors.New("failed dumping public key der")
 	}
+	runtime.KeepAlive(key)
 
 	return ioutil.ReadAll(asAnyBio(bio))
 }
@@ -306,6 +322,7 @@ func LoadPrivateKeyFromPEM(pem_block []byte) (PrivateKey, error) {
 	}
 	bio := C.BIO_new_mem_buf(unsafe.Pointer(&pem_block[0]),
 		C.int(len(pem_block)))
+	runtime.KeepAlive(pem_block)
 	if bio == nil {
 		return nil, errors.New("failed creating bio")
 	}
@@ -331,6 +348,7 @@ func LoadPrivateKeyFromPEMWithPassword(pem_block []byte, password string) (
 	}
 	bio := C.BIO_new_mem_buf(unsafe.Pointer(&pem_block[0]),
 		C.int(len(pem_block)))
+	runtime.KeepAlive(pem_block)
 	if bio == nil {
 		return nil, errors.New("failed creating bio")
 	}
@@ -356,6 +374,7 @@ func LoadPrivateKeyFromDER(der_block []byte) (PrivateKey, error) {
 	}
 	bio := C.BIO_new_mem_buf(unsafe.Pointer(&der_block[0]),
 		C.int(len(der_block)))
+	runtime.KeepAlive(der_block)
 	if bio == nil {
 		return nil, errors.New("failed creating bio")
 	}
@@ -387,6 +406,7 @@ func LoadPublicKeyFromPEM(pem_block []byte) (PublicKey, error) {
 	}
 	bio := C.BIO_new_mem_buf(unsafe.Pointer(&pem_block[0]),
 		C.int(len(pem_block)))
+	runtime.KeepAlive(pem_block)
 	if bio == nil {
 		return nil, errors.New("failed creating bio")
 	}
@@ -411,6 +431,7 @@ func LoadPublicKeyFromDER(der_block []byte) (PublicKey, error) {
 	}
 	bio := C.BIO_new_mem_buf(unsafe.Pointer(&der_block[0]),
 		C.int(len(der_block)))
+	runtime.KeepAlive(der_block)
 	if bio == nil {
 		return nil, errors.New("failed creating bio")
 	}
@@ -428,23 +449,39 @@ func LoadPublicKeyFromDER(der_block []byte) (PublicKey, error) {
 	return p, nil
 }
 
-// GenerateRSAKey generates a new RSA private key with an exponent of 3.
+// GenerateRSAKey generates a new RSA private key with an exponent of 65537.
 func GenerateRSAKey(bits int) (PrivateKey, error) {
-	return GenerateRSAKeyWithExponent(bits, 3)
+	return GenerateRSAKeyWithExponent(bits, 65537)
 }
 
 // GenerateRSAKeyWithExponent generates a new RSA private key.
 func GenerateRSAKeyWithExponent(bits int, exponent int) (PrivateKey, error) {
-	rsa := C.RSA_generate_key(C.int(bits), C.ulong(exponent), nil, nil)
+	exp := C.BN_new()
+	if exp == nil {
+		return nil, errors.New("failed to allocate BIGNUM for the exponent")
+	}
+	defer C.BN_free(exp)
+	rsa := C.RSA_new()
 	if rsa == nil {
+		return nil, errors.New("failed to allocate RSA key")
+	}
+	ret := C.BN_set_word(exp, C.ulong(uint(exponent)))
+	if ret == 0 {
+		C.RSA_free(rsa)
+		return nil, errors.New("error assigning exponent to BIGNUM")
+	}
+	ret = C.RSA_generate_key_ex(rsa, C.int(bits), exp, nil)
+	if ret == 0 {
+		C.RSA_free(rsa)
 		return nil, errors.New("failed to generate RSA key")
 	}
 	key := C.X_EVP_PKEY_new()
 	if key == nil {
+		C.RSA_free(rsa)
 		return nil, errors.New("failed to allocate EVP_PKEY")
 	}
 	if C.X_EVP_PKEY_assign_charp(key, C.EVP_PKEY_RSA, (*C.char)(unsafe.Pointer(rsa))) != 1 {
-		C.X_EVP_PKEY_free(key)
+		C.RSA_free(rsa)
 		return nil, errors.New("failed to assign RSA key")
 	}
 	p := &pKey{key: key}

--- a/md4.go
+++ b/md4.go
@@ -54,6 +54,7 @@ func (s *MD4Hash) Reset() error {
 	if 1 != C.X_EVP_DigestInit_ex(s.ctx, C.X_EVP_md4(), engineRef(s.engine)) {
 		return errors.New("openssl: md4: cannot init digest ctx")
 	}
+	runtime.KeepAlive(s)
 	return nil
 }
 
@@ -65,6 +66,7 @@ func (s *MD4Hash) Write(p []byte) (n int, err error) {
 		C.size_t(len(p))) {
 		return 0, errors.New("openssl: md4: cannot update digest")
 	}
+	runtime.KeepAlive(s)
 	return len(p), nil
 }
 

--- a/md5.go
+++ b/md5.go
@@ -54,6 +54,7 @@ func (s *MD5Hash) Reset() error {
 	if 1 != C.X_EVP_DigestInit_ex(s.ctx, C.X_EVP_md5(), engineRef(s.engine)) {
 		return errors.New("openssl: md5: cannot init digest ctx")
 	}
+	runtime.KeepAlive(s)
 	return nil
 }
 
@@ -65,6 +66,7 @@ func (s *MD5Hash) Write(p []byte) (n int, err error) {
 		C.size_t(len(p))) {
 		return 0, errors.New("openssl: md5: cannot update digest")
 	}
+	runtime.KeepAlive(s)
 	return len(p), nil
 }
 

--- a/net.go
+++ b/net.go
@@ -17,6 +17,7 @@ package openssl
 import (
 	"errors"
 	"net"
+	"runtime"
 )
 
 type listener struct {
@@ -30,6 +31,7 @@ func (l *listener) Accept() (c net.Conn, err error) {
 		return nil, err
 	}
 	ssl_c, err := Server(c, l.ctx)
+	runtime.KeepAlive(l.ctx)
 	if err != nil {
 		c.Close()
 		return nil, err
@@ -77,7 +79,9 @@ const (
 // This library is not nice enough to use the system certificate store by
 // default for you yet.
 func Dial(network, addr string, ctx *Ctx, flags DialFlags) (*Conn, error) {
-	return DialSession(network, addr, ctx, flags, nil)
+	conn, err := DialSession(network, addr, ctx, flags, nil)
+	runtime.KeepAlive(ctx)
+	return conn, err
 }
 
 // DialSession will connect to network/address and then wrap the corresponding

--- a/sha1.go
+++ b/sha1.go
@@ -61,6 +61,7 @@ func (s *SHA1Hash) Reset() error {
 	if 1 != C.X_EVP_DigestInit_ex(s.ctx, C.X_EVP_sha1(), engineRef(s.engine)) {
 		return errors.New("openssl: sha1: cannot init digest ctx")
 	}
+	runtime.KeepAlive(s)
 	return nil
 }
 
@@ -72,6 +73,7 @@ func (s *SHA1Hash) Write(p []byte) (n int, err error) {
 		C.size_t(len(p))) {
 		return 0, errors.New("openssl: sha1: cannot update digest")
 	}
+	runtime.KeepAlive(s)
 	return len(p), nil
 }
 

--- a/sha256.go
+++ b/sha256.go
@@ -54,6 +54,7 @@ func (s *SHA256Hash) Reset() error {
 	if 1 != C.X_EVP_DigestInit_ex(s.ctx, C.X_EVP_sha256(), engineRef(s.engine)) {
 		return errors.New("openssl: sha256: cannot init digest ctx")
 	}
+	runtime.KeepAlive(s)
 	return nil
 }
 
@@ -65,6 +66,7 @@ func (s *SHA256Hash) Write(p []byte) (n int, err error) {
 		C.size_t(len(p))) {
 		return 0, errors.New("openssl: sha256: cannot update digest")
 	}
+	runtime.KeepAlive(s)
 	return len(p), nil
 }
 

--- a/ssl.go
+++ b/ssl.go
@@ -19,6 +19,7 @@ import "C"
 
 import (
 	"os"
+	"runtime"
 	"unsafe"
 )
 
@@ -68,7 +69,9 @@ func go_ssl_verify_cb_thunk(p unsafe.Pointer, ok C.int, ctx *C.X509_STORE_CTX) C
 // Wrapper around SSL_get_servername. Returns server name according to rfc6066
 // http://tools.ietf.org/html/rfc6066.
 func (s *SSL) GetServername() string {
-	return C.GoString(C.SSL_get_servername(s.ssl, C.TLSEXT_NAMETYPE_host_name))
+	ret := C.GoString(C.SSL_get_servername(s.ssl, C.TLSEXT_NAMETYPE_host_name))
+	runtime.KeepAlive(s)
+	return ret
 }
 
 // same as GetSecurityLevel but for use without pointer to SSL
@@ -79,31 +82,40 @@ func GetSecurityLevelGlobal() int {
 // GetSecurityLevel gets the SSL security level. See
 // https://www.openssl.org/docs/ssl/SSL_get_security_level.html
 func (s *SSL) GetSecurityLevel() int {
-	return int(C.X_SSL_get_security_level(s.ssl))
+	ret := int(C.X_SSL_get_security_level(s.ssl))
+	runtime.KeepAlive(s)
+	return ret
 }
 
 // SetSecurityLevel sets the SSL security level. See
 // https://www.openssl.org/docs/ssl/SSL_set_security_level.html
 func (s *SSL) SetSecurityLevel(level int) {
 	C.X_SSL_set_security_level(s.ssl, C.int(level))
+	runtime.KeepAlive(s)
 }
 
 // GetOptions returns SSL options. See
 // https://www.openssl.org/docs/ssl/SSL_CTX_set_options.html
 func (s *SSL) GetOptions() Options {
-	return Options(C.X_SSL_get_options(s.ssl))
+	ret := Options(C.X_SSL_get_options(s.ssl))
+	runtime.KeepAlive(s)
+	return ret
 }
 
 // SetOptions sets SSL options. See
 // https://www.openssl.org/docs/ssl/SSL_CTX_set_options.html
 func (s *SSL) SetOptions(options Options) Options {
-	return Options(C.X_SSL_set_options(s.ssl, C.long(options)))
+	ret := Options(C.X_SSL_set_options(s.ssl, C.long(options)))
+	runtime.KeepAlive(s)
+	return ret
 }
 
 // ClearOptions clear SSL options. See
 // https://www.openssl.org/docs/ssl/SSL_CTX_set_options.html
 func (s *SSL) ClearOptions(options Options) Options {
-	return Options(C.X_SSL_clear_options(s.ssl, C.long(options)))
+	ret := Options(C.X_SSL_clear_options(s.ssl, C.long(options)))
+	runtime.KeepAlive(s)
+	return ret
 }
 
 // SetVerify controls peer verification settings. See
@@ -115,18 +127,21 @@ func (s *SSL) SetVerify(options VerifyOptions, verify_cb VerifyCallback) {
 	} else {
 		C.SSL_set_verify(s.ssl, C.int(options), nil)
 	}
+	runtime.KeepAlive(s)
 }
 
 // SetVerifyMode controls peer verification setting. See
 // http://www.openssl.org/docs/ssl/SSL_CTX_set_verify.html
 func (s *SSL) SetVerifyMode(options VerifyOptions) {
 	s.SetVerify(options, s.verify_cb)
+	runtime.KeepAlive(s)
 }
 
 // SetVerifyCallback controls peer verification setting. See
 // http://www.openssl.org/docs/ssl/SSL_CTX_set_verify.html
 func (s *SSL) SetVerifyCallback(verify_cb VerifyCallback) {
 	s.SetVerify(s.VerifyMode(), verify_cb)
+	runtime.KeepAlive(s)
 }
 
 // GetVerifyCallback returns callback function. See
@@ -138,7 +153,9 @@ func (s *SSL) GetVerifyCallback() VerifyCallback {
 // VerifyMode returns peer verification setting. See
 // http://www.openssl.org/docs/ssl/SSL_CTX_set_verify.html
 func (s *SSL) VerifyMode() VerifyOptions {
-	return VerifyOptions(C.SSL_get_verify_mode(s.ssl))
+	ret := VerifyOptions(C.SSL_get_verify_mode(s.ssl))
+	runtime.KeepAlive(s)
+	return ret
 }
 
 // SetVerifyDepth controls how many certificates deep the certificate
@@ -146,13 +163,16 @@ func (s *SSL) VerifyMode() VerifyOptions {
 // https://www.openssl.org/docs/ssl/SSL_CTX_set_verify.html
 func (s *SSL) SetVerifyDepth(depth int) {
 	C.SSL_set_verify_depth(s.ssl, C.int(depth))
+	runtime.KeepAlive(s)
 }
 
 // GetVerifyDepth controls how many certificates deep the certificate
 // verification logic is willing to follow a certificate chain. See
 // https://www.openssl.org/docs/ssl/SSL_CTX_set_verify.html
 func (s *SSL) GetVerifyDepth() int {
-	return int(C.SSL_get_verify_depth(s.ssl))
+	ret := int(C.SSL_get_verify_depth(s.ssl))
+	runtime.KeepAlive(s)
+	return ret
 }
 
 // SetSSLCtx changes context to new one. Useful for Server Name Indication (SNI)
@@ -164,6 +184,8 @@ func (s *SSL) SetSSLCtx(ctx *Ctx) {
 	 * adjust other things we care about
 	 */
 	C.SSL_set_SSL_CTX(s.ssl, ctx.ctx)
+	runtime.KeepAlive(s)
+	runtime.KeepAlive(ctx)
 }
 
 //export sni_cb_thunk

--- a/ssl_test.go
+++ b/ssl_test.go
@@ -200,11 +200,6 @@ func SimpleConnTest(t testing.TB, constructor func(
 		if string(buf.Bytes()) != data {
 			t.Fatal("mismatched data")
 		}
-
-		err = server.Close()
-		if err != nil {
-			t.Fatal(err)
-		}
 	}()
 	wg.Wait()
 }
@@ -265,12 +260,12 @@ func ClosingTest(t testing.TB, constructor func(
 
 		go func() {
 			defer wg.Done()
-			data, err := ioutil.ReadAll(sslconn2)
-			if err != nil {
-				t.Fatal(err)
-			}
+			data, _ := ioutil.ReadAll(sslconn2)
 			if !bytes.Equal(data, []byte("hello")) {
-				t.Fatal("bytes don't match")
+				t.Fatal(`bytes don't match: "` +
+					string(data) +
+					`" != "hello"`,
+				)
 			}
 		}()
 


### PR DESCRIPTION
This PR involves some updates and changes involving protecting C structures from accidentally being finalized when entering C context.
I also fixed the race issue in the unit tests.