### PR TITLE
Fix: Mirror the OpenSSL library name with the wrapper

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -603,10 +603,10 @@ func (c *Ctx) SessGetCacheSize() int {
 	return int(C.X_SSL_CTX_sess_get_cache_size(c.ctx))
 }
 
-// SetDefaultVerifyLocations
+// SetDefaultVerifyPaths
 // https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_set_default_verify_paths.html
 // enables automatical loading of default trust store from the `certs' subdirectory
 // and `cert.pem' file in the OPENSSL_DIR (check with `openssl version -d')
-func (c *Ctx) SetDefaultVerifyLocations() int {
+func (c *Ctx) SetDefaultVerifyPaths() int {
 	return int(C.SSL_CTX_set_default_verify_paths(c.ctx))
 }

--- a/ctx.go
+++ b/ctx.go
@@ -605,7 +605,7 @@ func (c *Ctx) SessGetCacheSize() int {
 
 // SetDefaultVerifyPaths
 // https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_set_default_verify_paths.html
-// enables automatical loading of default trust store from the `certs' subdirectory
+// enables automatic loading of the default trust store from the `certs' subdirectory
 // and `cert.pem' file in the OPENSSL_DIR (check with `openssl version -d')
 func (c *Ctx) SetDefaultVerifyPaths() int {
 	return int(C.SSL_CTX_set_default_verify_paths(c.ctx))

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -65,7 +65,10 @@ func TestCtxSetDefaultVerifyLocations(t *testing.T) {
 		t.Error("cant create context")
 	}
 
-	ctx.SetDefaultVerifyLocations()
+	if ctx.SetDefaultVerifyPaths() != 1 {
+		t.Errorf("set_default_verify_paths OpenSSL call failed")
+	}
+
 	conn, err = Dial("tcp", "google.com:443", ctx, 0)
 	v = conn.VerifyResult()
 


### PR DESCRIPTION
Just a quick fix on asymmetric naming in the wrapper