### PR TITLE
Add: GetDefaultCertificateDirectory method

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -610,3 +610,13 @@ func (c *Ctx) SessGetCacheSize() int {
 func (c *Ctx) SetDefaultVerifyPaths() int {
 	return int(C.SSL_CTX_set_default_verify_paths(c.ctx))
 }
+
+// GetDefaultCertificateDirectory returns the default directory for the system
+// certificates.
+func GetDefaultCertificateDirectory() (string, error) {
+	dir := C.GoString(C.X509_get_default_cert_dir())
+	if dir == "" {
+		return "", errors.New("Failed to get the OpenSSL directory variable")
+	}
+	return dir, nil
+}

--- a/ctx_test.go
+++ b/ctx_test.go
@@ -76,3 +76,16 @@ func TestCtxSetDefaultVerifyLocations(t *testing.T) {
 		t.Errorf("expected: Ok, got: %d", v)
 	}
 }
+
+// TestGetDefaultCertificateDirectory returns the default directory for CA
+// certificates on the system.
+func TestGetDefaultCertificateDirectory(t *testing.T) {
+	defDir, err := GetDefaultCertificateDirectory()
+	if err != nil {
+		t.Errorf("Failed to get the default certificate directory. '%v'", err)
+	}
+
+	if len(defDir) == 0 {
+		t.Errorf("Error: GetDefaultCertificateDirectory() returned a zero length string, but no error")
+	}
+}


### PR DESCRIPTION
This is needed, in order for us to verify that the system cert directory is set,
and that it is not empty

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>