### PR TITLE
Fix: Typecast error on some platforms during build

### DIFF
--- a/key.go
+++ b/key.go
@@ -467,7 +467,7 @@ func GenerateRSAKeyWithExponent(bits int, exponent int) (PrivateKey, error) {
 	if rsa == nil {
 		return nil, errors.New("failed to allocate RSA key")
 	}
-	ret := C.BN_set_word(exp, C.ulong(uint(exponent)))
+	ret := C.BN_set_word(exp, C.BN_ULONG(exponent))
 	if ret == 0 {
 		C.RSA_free(rsa)
 		return nil, errors.New("error assigning exponent to BIGNUM")


### PR DESCRIPTION
During testing of our Beaglebone Black, we were faced with some compilation
errors of OpenSSL, due to the previous explicit typecast to 'ulong' was wrong
for this platform.

This fix avoids having to manually cast to ulong, uint, or whatever OpenSSL
compiles to on the specific platform. Instead it uses a macro that comes with
the OpenSSL library by the name of 'BN_ULONG'. According to the documentation:

https://www.openssl.org/docs/man1.1.1/man3/BN_set_word.html

'BN_ULONG is a macro that will be an unsigned integral type optimized for the
most efficient implementation on the local platform'.

Thus, doing this macro call is the intended way of typecasting, so that we don't
have to do manual #ifdefs

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>