### PR TITLE
Skip the TestCtxSetDefaultVerifyLocations in case of no connectivity.

### DIFF
--- a/ctx_test.go
+++ b/ctx_test.go
@@ -54,6 +54,9 @@ func TestCtxSetDefaultVerifyLocations(t *testing.T) {
 	}
 
 	conn, err := Dial("tcp", "google.com:443", ctx, 0)
+	if conn == nil || err != nil {
+		t.Skip("can't connect, skipping the test.")
+	}
 	v := conn.VerifyResult()
 
 	if v != UnableToGetIssuerCertLocally {


### PR DESCRIPTION
Support unit testing for environments where network connectivity
is not enabled.

* in case we cant connect to live host, skip the test where we check the
  default trust store against remote host.

ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>